### PR TITLE
Added possibility to specifiy a rule as a string

### DIFF
--- a/pyspel.py
+++ b/pyspel.py
@@ -566,6 +566,8 @@ class Problem:
     def __add(self, definition):
         if issubclass(type(definition), Atom):
             definition = Define(definition)
+        if isinstance(definition, str):
+            definition = Define(definition)
         if not isinstance(definition, Definition):
             raise ValueError("Expected rule, got %s" % type(definition))
         self.rules.append(definition)


### PR DESCRIPTION
Sometimes for prototyping is faster to specify a rule as a string.

Weak constraints are still a problem since, when the problem gets converted to string, it always puts a `.` at the end of the rule, while in weak constraints it's put in between the rule and the tag.